### PR TITLE
bring badger notification to front each time badger button is clicked

### DIFF
--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -449,7 +449,7 @@ function triggerUi () {
     const currentlyActiveMetamaskTab = Boolean(
       tabs.find(tab => openMetamaskTabsIDs[tab.id])
     )
-    if (!popupIsOpen && !currentlyActiveMetamaskTab && !notificationIsOpen) {
+    if (!popupIsOpen && !currentlyActiveMetamaskTab) { // && !notificationIsOpen) {
       notificationManager.showPopup()
     }
   })


### PR DESCRIPTION
After user clicks badger button a notification window is displayed to the user for payment confirmation.  If this notification gets sent to the background, then subsequent clicks on the badger button don't bring notification to foreground.  You can only see the counter in the badger increase in number and the user is unaware the notification is hidden in the background.

This update forces the badger notification window to be brought to the front each time badger button is clicked.
